### PR TITLE
YTI-3951 changes related to terminology search in datamodel-api v2

### DIFF
--- a/src/main/java/fi/vm/yti/common/enums/Status.java
+++ b/src/main/java/fi/vm/yti/common/enums/Status.java
@@ -1,6 +1,7 @@
 package fi.vm.yti.common.enums;
 
 public enum Status {
+    INCOMPLETE,
     DRAFT,
     VALID,
     SUPERSEDED,

--- a/src/main/java/fi/vm/yti/common/opensearch/OpenSearchUtil.java
+++ b/src/main/java/fi/vm/yti/common/opensearch/OpenSearchUtil.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayOutputStream;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.json.stream.JsonGenerator;
 import org.opensearch.client.json.JsonpMapper;
 import org.opensearch.client.json.JsonpSerializable;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
@@ -36,6 +37,19 @@ public class OpenSearchUtil {
             LOG.debug("Payload for object of type {} in index {}", object.getClass().getSimpleName(), index);
             LOG.debug(out.toString());
         }
+    }
+
+    /**
+     * Serialize object to JSON
+     * @param object object to serialize
+     * @return object as JSON string
+     */
+    public static String getPayload(JsonpSerializable object) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        JsonGenerator generator = MAPPER.jsonProvider().createGenerator(out);
+        MAPPER.serialize(object, generator);
+        generator.close();
+        return out.toString();
     }
 
 


### PR DESCRIPTION
"INCOMPLETE" status is needed in terminologies. Currently we keep all statuses in one enum. In future, it might be worth considering moving status enum away from common library.