### PR TITLE
changes to fuseki health check method

### DIFF
--- a/src/main/java/fi/vm/yti/common/repository/BaseRepository.java
+++ b/src/main/java/fi/vm/yti/common/repository/BaseRepository.java
@@ -158,10 +158,9 @@ public abstract class BaseRepository {
                 .addWhere("?s", "?p", "?o")
                 .setLimit(1)
                 .build();
-        try {
-            return this.queryAsk(query);
-        } catch (Exception e) {
-            return false;
-        }
+        this.queryAsk(query); // may return true or false, depending on if there is any data
+
+        // If the queryAsk method does not throw an exception, the connection is healthy
+        return true;
     }
 }


### PR DESCRIPTION
The health check should just check for connectivity, and then rethrow any possible exception so the caller can get the exception details.