### PR TITLE
changes for datamodel-api to further utilize yti-common-backend

### DIFF
--- a/src/main/java/fi/vm/yti/common/config/SpringAsyncConfig.java
+++ b/src/main/java/fi/vm/yti/common/config/SpringAsyncConfig.java
@@ -1,0 +1,23 @@
+package fi.vm.yti.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.security.task.DelegatingSecurityContextAsyncTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class SpringAsyncConfig implements AsyncConfigurer {
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+        taskExecutor.setCorePoolSize(15);
+        taskExecutor.setMaxPoolSize(50);
+        taskExecutor.setQueueCapacity(100);
+        taskExecutor.initialize();
+        return new DelegatingSecurityContextAsyncTaskExecutor(taskExecutor);
+    }
+}

--- a/src/main/java/fi/vm/yti/common/exception/ExceptionHandlerAdvice.java
+++ b/src/main/java/fi/vm/yti/common/exception/ExceptionHandlerAdvice.java
@@ -86,7 +86,7 @@ public class ExceptionHandlerAdvice extends ResponseEntityExceptionHandler {
         return buildResponseEntity(apiError);
     }
 
-    public ResponseEntity<Object> buildResponseEntity(ApiError apiError) {
+    protected ResponseEntity<Object> buildResponseEntity(ApiError apiError) {
         return new ResponseEntity<>(apiError, apiError.getStatus());
     }
 }

--- a/src/main/java/fi/vm/yti/common/security/SecurityConfig.java
+++ b/src/main/java/fi/vm/yti/common/security/SecurityConfig.java
@@ -1,0 +1,35 @@
+package fi.vm.yti.common.security;
+
+import fi.vm.yti.security.config.FakeUserLogin;
+import fi.vm.yti.security.config.FakeUserLoginProvider;
+import fi.vm.yti.security.config.SecurityBaseConfig;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@Import(SecurityBaseConfig.class)
+public class SecurityConfig {
+
+    private final @Nullable String fakeLoginMail;
+    private final @Nullable String fakeLoginFirstName;
+    private final @Nullable String fakeLoginLastName;
+
+    SecurityConfig(@Value("${fake.login.mail:}") @Nullable String fakeLoginMail,
+                   @Value("${fake.login.firstName:}") @Nullable String fakeLoginFirstName,
+                   @Value("${fake.login.lastName:}") @Nullable String fakeLoginLastName) {
+
+        this.fakeLoginMail = fakeLoginMail;
+        this.fakeLoginFirstName = fakeLoginFirstName;
+        this.fakeLoginLastName = fakeLoginLastName;
+    }
+
+    @Bean
+    @ConditionalOnProperty("fake.login.mail")
+    FakeUserLoginProvider fakeUserLoginProvider() {
+        return () -> new FakeUserLogin(fakeLoginMail, fakeLoginFirstName, fakeLoginLastName);
+    }
+}

--- a/src/main/java/fi/vm/yti/common/validator/BaseValidator.java
+++ b/src/main/java/fi/vm/yti/common/validator/BaseValidator.java
@@ -68,6 +68,12 @@ public abstract class BaseValidator implements Annotation {
         }
     }
 
+    public void checkShouldBeNull(ConstraintValidatorContext context, Object value, String property) {
+        if (value != null) {
+            addConstraintViolation(context, ValidationConstants.MSQ_NOT_ALLOWED, property);
+        }
+    }
+
     public void checkHasValue(ConstraintValidatorContext context, String value, String property) {
         if (value == null || value.isBlank()) {
             addConstraintViolation(context, ValidationConstants.MSG_VALUE_MISSING, property);

--- a/src/main/java/fi/vm/yti/common/validator/ValidationConstants.java
+++ b/src/main/java/fi/vm/yti/common/validator/ValidationConstants.java
@@ -2,7 +2,7 @@ package fi.vm.yti.common.validator;
 
 public class ValidationConstants {
 
-    private ValidationConstants() {
+    protected ValidationConstants() {
         // constants
     }
 
@@ -15,11 +15,13 @@ public class ValidationConstants {
     public static final int TEXT_FIELD_MAX_LENGTH = 150;
     public static final int EMAIL_FIELD_MAX_LENGTH = 320;
     public static final int TEXT_AREA_MAX_LENGTH = 5000;
+    public static final int DOCUMENTATION_MAX_LENGTH = 50000;
 
     public static final int PREFIX_MIN_LENGTH = 2;
     public static final int PREFIX_MAX_LENGTH = 32;
-    public static final String PREFIX_REGEX = "^[a-z][a-z0-9-_]+";
 
-    public static final String RESOURCE_IDENTIFIER_REGEX = "^[a-zA-Z][a-zA-Z0-9-_]+";
+    public static final String PREFIX_REGEX = "^[a-z][a-z0-9-_]{1,31}";
+
+    public static final String RESOURCE_IDENTIFIER_REGEX = "^[a-zA-Z][a-zA-Z0-9-_]{1,119}";
 
 }


### PR DESCRIPTION
Configuration classes moved to common library:

* SpringAsyncConfig
* SecurityConfig

Small changes to classes that are now extended by datamodel-api:

* ExceptionHandlerAdvice
* BaseValidator
* ValidationConstants

NOTE: RESOURCE_IDENTIFIER_REGEX and PREFIX_REGEX now have length limits.